### PR TITLE
frontend search bandaid fix, still errors

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -82,7 +82,7 @@ export default function Home() {
   };
 
   useEffect(() => {
-    console.log(recipes)
+    // console.log(recipes)
     const bookmarkedRecipes = recipes.filter((recipe) => recipe.bookmarked);
     setBookmarkedRecipes(bookmarkedRecipes);
   }, [recipes]);
@@ -115,7 +115,7 @@ export default function Home() {
         return selectedTags.some((tag) => recipe.tags.includes(tag.slug));
       });
       setRecipes(filteredRecipes);
-      console.log(recipes)
+      // console.log(recipes)
     }
   };
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -82,7 +82,7 @@ export default function Home() {
   };
 
   useEffect(() => {
-    // console.log(recipes)
+    console.log(recipes)
     const bookmarkedRecipes = recipes.filter((recipe) => recipe.bookmarked);
     setBookmarkedRecipes(bookmarkedRecipes);
   }, [recipes]);
@@ -115,7 +115,7 @@ export default function Home() {
         return selectedTags.some((tag) => recipe.tags.includes(tag.slug));
       });
       setRecipes(filteredRecipes);
-      // console.log(recipes)
+      console.log(recipes)
     }
   };
 

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -15,14 +15,18 @@ const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
       try {
         const response = await fetch(endpoint);
         const data: Pagination<Recipe> = await response.json();
-        onSearch(data.records); // Call the callback function with the search results
+        if (query) {
+          onSearch(data);
+        } else {
+          onSearch(data.records);
+        }
       } catch (error) {
         console.error("An error occurred:", error);
       }
     }, 300) // The delay in ms
 
     return () => clearTimeout(delayDebounceFn)
-  }, [query])
+  }, [onSearch, query])
 
   return (
     <form className="relative text-gray-600 w-1/2">

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -29,5 +29,5 @@ export type Pagination<T> = {
 }
 
 export type SearchBarProps = {
-  onSearch: (searchResults: Recipe[]) => void;
+  onSearch: (searchResults: Recipe[] | Pagination<Recipe>) => void;
 };


### PR DESCRIPTION
search now works, but an error still exists:
if you search a recipe and click on one of them, then an error occurs.
ex:
1. search salad
2. click one of the recipes
3. error
```tsx
Unhandled Runtime Error
TypeError: Cannot read properties of undefined (reading 'map')

Source
src/components/InfoTabs.tsx (30:30) @ map

  28 | <ul className="ml-8 mr-2 my-6 leading-loose list-outside
  29 |     list-image-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTQiIGhlaWdodD0iMTIiIHZpZXdCb3g9IjAgMCAxNCAxMiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBmaWxsPSIjMzhiZGY4Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMy42ODUuMTUzYS43NTIuNzUyIDAgMCAxIC4xNDMgMS4wNTJsLTggMTAuNWEuNzUuNzUgMCAwIDEtMS4xMjcuMDc1bC00LjUtNC41YS43NS43NSAwIDAgMSAxLjA2LTEuMDZsMy44OTQgMy44OTMgNy40OC05LjgxN2EuNzUuNzUgMCAwIDEgMS4wNS0uMTQzWiIgLz48L3N2Zz4=')]">
> 30 |     { ingredients.map(({ unit, label, amount }, k) => (
     |                  ^
  31 |         <li key={ k }>{ amount } { unit } { label }</li>
  32 |     ))}
  33 | </ul>
```