### PR TITLE
frontend user auth validation fix

### DIFF
--- a/frontend/src/components/UserAuth.tsx
+++ b/frontend/src/components/UserAuth.tsx
@@ -141,8 +141,8 @@ const UserAuth: React.FC = () => {
                                     required
                                 />
                                 <PasswordChecklist
-                                    rules={["minLength","specialChar","number","capital"]}
-                                    minLength={5}
+                                    rules={["minLength","number","capital"]}
+                                    minLength={6}
                                     value={userPassword}
                                     onChange={(_isValid: any) => {}}
                                 />


### PR DESCRIPTION
- backend validates password to be minlength 6 and has at least one capital letter. 